### PR TITLE
Remove the version-v-prefix in releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,7 +230,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create v${{ needs.build.outputs.version }} \
+          gh release create ${{ needs.build.outputs.version }} \
             --draft \
-            --title "v${{ needs.build.outputs.version }}" \
+            --title "${{ needs.build.outputs.version }}" \
             --notes "${{ needs.build.outputs.changelog }}"


### PR DESCRIPTION
Remove the version-v-prefix in releases, as it appends on top of itself when creating PRs